### PR TITLE
Seek the configurations & update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,28 @@
 # TTX - CLI tool for Tarantool developers
 
+TTX is a CLI tool for [Tarantool](https://github.com/tarantool/tarantool) developers. It simplifies working with [Tarantool cluster configuration](https://www.tarantool.io/en/doc/latest/reference/configuration/configuration_reference/) and testing the clusters during the development.
+
+## Usage
+
+If you want to see how to use the utility run `ttx --help`.
+
+Simply run `ttx` to seek for the Tarantool `config.yml` files nearby and start the cluster based on them.
+
+```bash
+ttx
+# Or explicitly provide the configuration and start the cluster.
+ttx start config.yml
+```
+
+## Build & install
+
+To build & install ttx run the following bash script.
+
+```
+git clone https://github.com/georgiy-belyanin/ttx.git
+cd ttx
+go mod tidy
+go install
+```
+
+`ttx` will likely appear in `$GOPATH/bin/ttx` (i.e. `$HOME/go/bin/ttx`). Make sure this dir is added to your `$PATH`.

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,6 +1,9 @@
 package cmd
 
 import (
+	"fmt"
+
+	"github.com/georgiy-belyanin/ttx/runner"
 	"github.com/spf13/cobra"
 )
 
@@ -12,6 +15,13 @@ var rootCmd = &cobra.Command{
 TTX simplifies working with Tarantool configuration and testing the clusters
 during the development.
 `,
+
+	Run: func(cmd *cobra.Command, args []string) {
+		err := runner.RunClusterFromNearestConfig()
+		if err != nil {
+			fmt.Println(err)
+		}
+	},
 }
 
 func Execute() error {

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -8,15 +8,22 @@ import (
 )
 
 var startCmd = &cobra.Command{
-	Use:   "start <config.yml>",
+	Use:   "start [config.yml]",
 	Short: "Start Tarantool cluster",
 	Long:  `Start Tarantool cluster from the configuration`,
-	Args:  cobra.MinimumNArgs(1),
+	Args:  cobra.ArbitraryArgs,
 	Run: func(cmd *cobra.Command, args []string) {
-		configPath := args[0]
-		err := runner.RunClusterFromConfig(configPath)
+		var err error
+
+		if len(args) > 1 {
+			configPath := args[0]
+			err = runner.RunClusterFromConfig(configPath)
+		} else {
+			err = runner.RunClusterFromNearestConfig()
+		}
+
 		if err != nil {
-			fmt.Println("Unable to start the cluster from the config", err)
+			fmt.Println(err)
 		}
 	},
 }

--- a/config/utils.go
+++ b/config/utils.go
@@ -1,8 +1,10 @@
 package config
 
 import (
-	"gopkg.in/yaml.v3"
 	"os"
+	"path/filepath"
+
+	"gopkg.in/yaml.v3"
 )
 
 func LoadYamlFile(fileName string) (*Config, error) {
@@ -19,4 +21,35 @@ func LoadYamlFile(fileName string) (*Config, error) {
 	}
 
 	return &config, nil
+}
+
+var names = []string{
+	"config.yml",
+	"config.yaml",
+	"source.yml",
+	"source.yaml",
+}
+
+func FindYamlFileAtPath(path string) (string, error) {
+	dirEntries, err := os.ReadDir(path)
+	if err != nil {
+		return "", err
+	}
+
+	for _, name := range names {
+		for _, dirEntry := range dirEntries {
+			if dirEntry.IsDir() {
+				continue
+			}
+
+			fileName := dirEntry.Name()
+			if dirEntry.Name() != name {
+				continue
+			}
+
+			return filepath.Join(path, fileName), nil
+		}
+	}
+
+	return FindYamlFileAtPath(filepath.Join(path, ".."))
 }

--- a/runner/run.go
+++ b/runner/run.go
@@ -2,12 +2,14 @@ package runner
 
 import (
 	"bufio"
+	"errors"
 	"fmt"
-	"github.com/fatih/color"
-	"github.com/georgiy-belyanin/ttx/config"
 	"os/exec"
 	"strings"
 	"sync"
+
+	"github.com/fatih/color"
+	"github.com/georgiy-belyanin/ttx/config"
 )
 
 var InstanceColors = []*color.Color{
@@ -80,6 +82,22 @@ func RunClusterFromConfig(configPath string) error {
 		}()
 	}
 	wg.Wait()
+
+	return nil
+}
+
+func RunClusterFromNearestConfig() error {
+	configPath, err := config.FindYamlFileAtPath(".")
+	if err != nil {
+		return errors.New("unable to seek for any of the configuration files in the current directory and it's parent directories")
+	}
+
+	fmt.Println("Found configuration at", configPath)
+
+	err = RunClusterFromConfig(configPath)
+	if err != nil {
+		return fmt.Errorf("unable to start the cluster from the config file %s: %s", configPath, err)
+	}
 
 	return nil
 }


### PR DESCRIPTION
This is a patchset of two patches.

The first one adds seeking for Tarantool configurations in the current and
parent directories when the config isn't explicitly supplied.

The second one adds basic readme on how to use the utility.
