### PR TITLE
Run CI workflows on main pushes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,7 @@ name: Bulid
 on:
   push:
     branches:
-      - 'master'
+      - main
   pull_request:
 
 jobs:


### PR DESCRIPTION
This patch makes CI run workflows on push in main. Previously it didn't work since the build workflow worked on push in master.