### PR TITLE
Fix run cluster from config, add graceful shutdown and preciser logs

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/georgiy-belyanin/ttx/runner"
@@ -17,7 +18,7 @@ during the development.
 `,
 
 	Run: func(cmd *cobra.Command, args []string) {
-		err := runner.RunClusterFromNearestConfig()
+		err := runner.RunClusterFromNearestConfig(context.Background())
 		if err != nil {
 			fmt.Println(err)
 		}

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/georgiy-belyanin/ttx/runner"
@@ -15,11 +16,13 @@ var startCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		var err error
 
+		ctx := context.Background()
+
 		if len(args) > 1 {
 			configPath := args[0]
-			err = runner.RunClusterFromConfig(configPath)
+			err = runner.RunClusterFromConfig(ctx, configPath)
 		} else {
-			err = runner.RunClusterFromNearestConfig()
+			err = runner.RunClusterFromNearestConfig(ctx)
 		}
 
 		if err != nil {

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -18,7 +18,7 @@ var startCmd = &cobra.Command{
 
 		ctx := context.Background()
 
-		if len(args) > 1 {
+		if len(args) >= 1 {
 			configPath := args[0]
 			err = runner.RunClusterFromConfig(ctx, configPath)
 		} else {

--- a/runner/run.go
+++ b/runner/run.go
@@ -55,7 +55,7 @@ func runInstanceColored(ctx context.Context, instanceName string, configPath str
 
 	stderr, err := c1.StderrPipe()
 	if err != nil {
-		panic("fuck")
+		return err
 	}
 
 	scn := bufio.NewScanner(stderr)


### PR DESCRIPTION
This is a patchset introducing a few fixes into the start cluster from the
configuration logic making the `ttx start` commands more versatile.

- The first patch adds cluster's graceful shutdown on SIGINT.
- The second one color whole log Tarantool messages.
- The third one fixes inability to use start cmd with one argument.
- The fourth replaces error on instance start curse word panic with error.
