### PR TITLE
Fix error on unsupported Lua type function

### DIFF
--- a/console/connect.go
+++ b/console/connect.go
@@ -13,6 +13,7 @@ import (
 
 func evalLua(text string) string {
 	var evalLuaBase = `local yaml = require('yaml')
+yaml.cfg{ encode_use_tostring = true }
 local cmd = [[%s]]
 
 local f, err = loadstring("return " .. cmd)


### PR DESCRIPTION
This patch fixes an error in the console when Tarantool is unable to
encode function.

Reproduce the bug as follows.
```
> box.session
unsupported Lua type 'function' (LuajitError, code 0x20)...
```

It turns out Tarantool tries to encode some of the fields as functions.
It can be fixed by providing a configuration to `yaml` Lua module on the
server side.

```lua
yaml.cfg{ encode_use_tostring = true }
```

This is just a temporary fix which uses the same hack as tt.

